### PR TITLE
Resolve the 'self.version' constraint through packages from the root package

### DIFF
--- a/tests/ComposerPluginTest.php
+++ b/tests/ComposerPluginTest.php
@@ -827,6 +827,37 @@ class ComposerPluginTest extends TestCase
         $this->assertEquals(0, count($extraInstalls));
     }
 
+    /** @test */
+    public function it_can_resolve_self_version_constraint_through_packages_from_the_root_package()
+    {
+        $that = $this;
+        $dir  = $this->fixtureDir('it-can-resolve-self-version-constraint-through-packages-from-the-root-package');
+        $root = $this->rootFromJson("{$dir}/composer.json");
+
+        $root->setReplaces(Argument::type('array'))
+             ->will(function ($args) use ($that) {
+                 $replace = $args[0];
+                 $that->assertEquals(3, count($replace));
+
+                 $that->assertArrayHasKey('foo/bar',   $replace);
+                 $that->assertArrayHasKey('foo/baz',   $replace);
+                 $that->assertArrayHasKey('foo/xyzzy', $replace);
+
+                 $that->assertInstanceOf('Composer\Package\Link', $replace['foo/bar']);
+                 $that->assertInstanceOf('Composer\Package\Link', $replace['foo/baz']);
+                 $that->assertInstanceOf('Composer\Package\Link', $replace['foo/xyzzy']);
+
+                 $that->assertEquals('~8.0', $replace['foo/bar']->getPrettyConstraint());
+                 $that->assertEquals('~8.0', $replace['foo/baz']->getPrettyConstraint());
+                 $that->assertEquals('~1.0', $replace['foo/xyzzy']->getPrettyConstraint());
+            });
+
+        $root->getRequires()->shouldNotBeCalled();
+
+        $extraInstalls = $this->triggerPlugin($root->reveal(), $dir);
+        $this->assertEquals(0, count($extraInstalls));
+    }
+
     /* ------------------------------------------------------------------------------------------------
      |  Other Functions
      | ------------------------------------------------------------------------------------------------

--- a/tests/fixtures/it-can-resolve-self-version-constraint-through-packages-from-the-root-package/composer.json
+++ b/tests/fixtures/it-can-resolve-self-version-constraint-through-packages-from-the-root-package/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "foo/root",
+    "replace": {
+        "foo/bar": "~8.0"
+    },
+    "extra": {
+        "merge-plugin": {
+            "include": "composer.local.json"
+        }
+    }
+}

--- a/tests/fixtures/it-can-resolve-self-version-constraint-through-packages-from-the-root-package/composer.local.json
+++ b/tests/fixtures/it-can-resolve-self-version-constraint-through-packages-from-the-root-package/composer.local.json
@@ -1,0 +1,7 @@
+{
+    "name": "foo/bar",
+    "replace": {
+        "foo/baz": "self.version",
+        "foo/xyzzy": "~1.0"
+    }
+}


### PR DESCRIPTION
`foo/baz` should resolve to `~8.0` because the root composer.json requires `~8.0`.
