### PR TITLE
Allow merging "extra" in a deep way

### DIFF
--- a/src/Entities/PluginState.php
+++ b/src/Entities/PluginState.php
@@ -55,6 +55,22 @@ class PluginState
      */
     protected $mergeExtra = false;
 
+    /**
+     * Whether to merge the extra section in a deep / recursive way.
+     *
+     * By default the extra section is merged with array_merge() and duplicate keys are ignored.
+     * When enabled this allows to merge the arrays recursively using the following rule:
+     *   Integer keys are merged, while array values are replaced where the later values overwrite the former.
+     *
+     * This is useful especially for the extra section when plugins use larger structures like a 'patches' key with
+     * the packages as sub-keys and the patches as values.
+     *
+     * When 'replace' mode is activated the order of array merges is exchanged.
+     *
+     * @var bool
+     */
+    protected $mergeExtraDeep = false;
+
     /** @var bool */
     protected $firstInstall = false;
 
@@ -111,7 +127,7 @@ class PluginState
      */
     public function setFirstInstall($flag)
     {
-        $this->firstInstall = (bool)$flag;
+        $this->firstInstall = (bool) $flag;
 
         return $this;
     }
@@ -324,6 +340,16 @@ class PluginState
         return $this->mergeExtra;
     }
 
+    /**
+     * Should the extra section be merged deep / recursively?
+     *
+     * @return bool
+     */
+    public function shouldMergeExtraDeep()
+    {
+        return $this->mergeExtraDeep;
+    }
+
     /* ------------------------------------------------------------------------------------------------
      |  Main Functions
      | ------------------------------------------------------------------------------------------------
@@ -342,6 +368,7 @@ class PluginState
         $this->prependRepositories = (bool) $config['prepend-repositories'];
         $this->mergeDev            = (bool) $config['merge-dev'];
         $this->mergeExtra          = (bool) $config['merge-extra'];
+        $this->mergeExtraDeep      = (bool) $config['merge-extra-deep'];
 
     }
 
@@ -367,6 +394,7 @@ class PluginState
                 'prepend-repositories' => false,
                 'merge-dev'            => true,
                 'merge-extra'          => false,
+                'merge-extra-deep'     => false,
             ],
             isset($extra['merge-plugin']) ? $extra['merge-plugin'] : []
         );

--- a/src/Utilities/NestedArray.php
+++ b/src/Utilities/NestedArray.php
@@ -1,0 +1,65 @@
+<?php namespace Arcanedev\Composer\Utilities;
+
+/**
+ * Class     NestedArray
+ *
+ * @package  Arcanedev\Composer\Utilities
+ * @author   ARCANEDEV <arcanedev.maroc@gmail.com>
+ */
+class NestedArray
+{
+
+    /**
+     * Merges multiple arrays, recursively, and returns the merged array.
+     *
+     * This function is similar to PHP's array_merge_recursive() function, but it handles non-array values differently.
+     * When merging values that are not both arrays, the latter value replaces the former rather than merging with it.
+     *
+     *
+     * @return array
+     *
+     * @see NestedArray::mergeDeepArray()
+     */
+    public static function mergeDeep()
+    {
+        return self::mergeDeepArray(func_get_args());
+    }
+
+    /**
+     * Merges multiple arrays, recursively, and returns the merged array.
+     *
+     * This function is equivalent to NestedArray::mergeDeep(), except the input arrays are passed as a single array
+     * parameter rather than a variable parameter list.
+     *
+     * @param  array  $arrays
+     * @param  bool   $preserveIntegerKeys
+     *
+     * @return array
+     *
+     * @see NestedArray::mergeDeep()
+     */
+    public static function mergeDeepArray(array $arrays, $preserveIntegerKeys = false)
+    {
+        $result = [];
+
+        foreach ($arrays as $array) {
+            foreach ($array as $key => $value) {
+                // Renumber integer keys as array_merge_recursive() does unless $preserve_integer_keys is set to TRUE.
+                // Note that PHP automatically converts array keys that are integer strings (e.g., '1') to integers.
+                if (is_integer($key) && ! $preserveIntegerKeys) {
+                    $result[] = $value;
+                }
+                elseif (isset($result[$key]) && is_array($result[$key]) && is_array($value)) {
+                    // Recurse when both values are arrays.
+                    $result[$key] = self::mergeDeepArray(array($result[$key], $value), $preserveIntegerKeys);
+                }
+                else {
+                    // Otherwise, use the latter value, overriding any previous value.
+                    $result[$key] = $value;
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/Utilities/NestedArrayTest.php
+++ b/tests/Utilities/NestedArrayTest.php
@@ -1,0 +1,138 @@
+<?php namespace Arcanedev\Composer\Tests\Utilities;
+
+use Arcanedev\Composer\Tests\TestCase;
+use Arcanedev\Composer\Utilities\NestedArray;
+
+/**
+ * Class     NestedArrayTest
+ *
+ * @package  Arcanedev\Composer\Tests\Utilities
+ * @author   ARCANEDEV <arcanedev.maroc@gmail.com>
+ */
+class NestedArrayTest extends TestCase
+{
+    /* ------------------------------------------------------------------------------------------------
+     |  Test Functions
+     | ------------------------------------------------------------------------------------------------
+     */
+    /** @test */
+    public function it_can_merge_deep_array()
+    {
+        $arrayOne = [
+            'fragment'   => 'x',
+            'attributes' => ['title' => 'X', 'class' => ['a', 'b']],
+            'language'   => 'en',
+        ];
+
+        $arrayTwo = [
+            'fragment'   => 'y',
+            'attributes' => ['title' => 'Y', 'class' => ['c', 'd']],
+            'absolute'   => true,
+        ];
+
+        $expected = [
+            'fragment'   => 'y',
+            'attributes' => [
+                'title'  => 'Y', 'class' => ['a', 'b', 'c', 'd']
+            ],
+            'language'   => 'en',
+            'absolute'   => true,
+        ];
+
+        $this->assertSame(
+            $expected,
+            NestedArray::mergeDeepArray([$arrayOne, $arrayTwo]),
+            'NestedArray::mergeDeepArray() returned a properly merged array.'
+        );
+
+        // Test wrapper function, NestedArray::mergeDeep().
+        $this->assertSame(
+            $expected,
+            NestedArray::mergeDeep($arrayOne, $arrayTwo),
+            'NestedArray::mergeDeep() returned a properly merged array.'
+        );
+    }
+
+    /** @test */
+    public function it_can_merge_implicit_keys()
+    {
+        $arrayOne = [
+            'subkey' => ['X', 'Y'],
+        ];
+        $arrayTwo = [
+            'subkey' => ['X'],
+        ];
+
+        $this->assertSame(
+            [
+                'subkey' => ['X', 'Y', 'X'], // Drupal core behavior.
+            ],
+            NestedArray::mergeDeepArray([$arrayOne, $arrayTwo]),
+            'mergeDeepArray::mergeDeepArray creates new numeric keys in the implicit sequence.'
+        );
+    }
+
+    /** @test */
+    public function it_can_merge_explicit_keys()
+    {
+        $arrayOne = [
+            'subkey' => [
+                0 => 'A',
+                1 => 'B',
+            ],
+        ];
+
+        $arrayTwo = [
+            'subkey' => [
+                0 => 'C',
+                1 => 'D',
+            ],
+        ];
+
+        $this->assertSame(
+            [
+                // Drupal core behavior.
+                'subkey' => [
+                    0 => 'A',
+                    1 => 'B',
+                    2 => 'C',
+                    3 => 'D',
+                ],
+            ],
+            NestedArray::mergeDeepArray([$arrayOne, $arrayTwo]),
+            'NestedArray::mergeDeepArray creates new numeric keys in the explicit sequence.'
+        );
+    }
+
+    /** @test */
+    public function it_can_merge_out_of_sequence_keys()
+    {
+        $arrayOne = [
+            'subkey' => [
+                10 => 'A',
+                30 => 'B',
+            ],
+        ];
+
+        $arrayTwo = [
+            'subkey' => [
+                20 => 'C',
+                0 => 'D',
+            ],
+        ];
+
+        $this->assertSame(
+            [
+                // Drupal core behavior.
+                'subkey' => [
+                    0 => 'A',
+                    1 => 'B',
+                    2 => 'C',
+                    3 => 'D',
+                ],
+            ],
+            NestedArray::mergeDeepArray([$arrayOne, $arrayTwo]),
+            'NestedArray::mergeDeepArray ignores numeric key order when merging.'
+        );
+    }
+}

--- a/tests/fixtures/merge-extra-deep-replace/composer.json
+++ b/tests/fixtures/merge-extra-deep-replace/composer.json
@@ -1,0 +1,22 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "merge-extra": true,
+            "merge-extra-deep": true,
+            "replace": true,
+            "include": "composer.local.json"
+        },
+        "patches": {
+            "arcanedev/composer": {
+                "Add tests for merge-extra-deep option": "patches/add-tests-for-merge-extra-deep-option.diff"
+            },
+            "somevendor/some-project": {
+                "some-patch": "patches/some-patch.diff"
+            },
+            "anothervendor/some-project": {
+                "another-patch": "patches/another-patch.diff"
+            }
+        },
+        "list": [ "first", "second" ]
+    }
+}

--- a/tests/fixtures/merge-extra-deep-replace/composer.local.json
+++ b/tests/fixtures/merge-extra-deep-replace/composer.local.json
@@ -1,0 +1,13 @@
+{
+    "extra": {
+        "patches": {
+            "arcanedev/composer": {
+                "Allow merging of sections in a deep way": "patches/add-merge-extra-deep-option.diff"
+            },
+            "somevendor/some-project": {
+                "some-patch": "patches/overridden-patch.diff"
+            }
+        },
+        "list": [ "third", "fourth" ]
+    }
+}

--- a/tests/fixtures/merge-extra-deep/composer.json
+++ b/tests/fixtures/merge-extra-deep/composer.json
@@ -1,0 +1,22 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "merge-extra": true,
+            "merge-extra-deep": true,
+            "replace": false,
+            "include": "composer.local.json"
+        },
+        "patches": {
+            "arcanedev/composer": {
+                "Add tests for merge-extra-deep option": "patches/add-tests-for-merge-extra-deep-option.diff"
+            },
+            "somevendor/some-project": {
+                "some-patch": "patches/overridden-patch.diff"
+            },
+            "anothervendor/some-project": {
+                "another-patch": "patches/another-patch.diff"
+            }
+        },
+        "list": [ "third", "fourth" ]
+    }
+}

--- a/tests/fixtures/merge-extra-deep/composer.local.json
+++ b/tests/fixtures/merge-extra-deep/composer.local.json
@@ -1,0 +1,14 @@
+{
+    "extra": {
+        "patches": {
+            "arcanedev/composer": {
+                "Allow merging of sections in a deep way": "patches/add-merge-extra-deep-option.diff"
+            },
+            "somevendor/some-project": {
+                "some-patch": "patches/standard-way-to-patch.diff",
+                "base-patch": "patches/always-patch.diff"
+            }
+        },
+        "list": [ "first", "second" ]
+    }
+}


### PR DESCRIPTION
Introduce a new "merge-extra-deep" configuration setting to control merging the "extra" section of included/required files in a way similar to to array_merge_recursive() - however duplicate string array keys are replaced instead of merged, while numeric array keys are merged as usual.
