### PR TITLE
Use dev mode flag from event in onDependencySolve callback

### DIFF
--- a/src/ComposerPlugin.php
+++ b/src/ComposerPlugin.php
@@ -144,7 +144,10 @@ class ComposerPlugin implements PluginInterface, EventSubscriberInterface
             $request, $this->state->getDuplicateLinks('require')
         );
 
-        if ($this->state->isDevMode()) {
+        // Check devMode of event rather than our global state.
+        // Composer fires the PRE_DEPENDENCIES_SOLVING event twice for `--no-dev`
+        // operations to decide which packages are dev only requirements.
+        if ($this->state->shouldMergeDev() && $event->isDevMode()) {
             $this->installRequires(
                 $request, $this->state->getDuplicateLinks('require-dev'), true
             );

--- a/src/Entities/PluginState.php
+++ b/src/Entities/PluginState.php
@@ -197,7 +197,17 @@ class PluginState
      */
     public function isDevMode()
     {
-        return $this->mergeDev && $this->devMode;
+        return $this->shouldMergeDev() && $this->devMode;
+    }
+
+    /**
+     * Should devMode settings be merged?
+     *
+     * @return bool
+     */
+    public function shouldMergeDev()
+    {
+        return $this->mergeDev;
     }
 
     /**


### PR DESCRIPTION
Composer determines if a given package is a dev mode dependency by running a solver with dev mode disabled and diffing the result against the full solver run. 
This causes every run to two emit `InstallerEvents::PRE_DEPENDENCIES_SOLVING` events: one with dev mode enabled and one without. Previously we were using the global dev mode state set by the main install/update/dump event for both calls. This led Composer to believe that all conflicting pacakges processed by `composer` package were non-dev requirements and an unexpected `composer.lock` state for later `composer install --no-dev` executions.
